### PR TITLE
Remove TLD restrictions.

### DIFF
--- a/ns_petname.py
+++ b/ns_petname.py
@@ -4,10 +4,10 @@
 import sys
 
 pet_names = {
-    'txtorcon': 'timaq4ygg2iegci7.onion',
-    'duckduckgo': '3g2upl4pq6kufc4m.onion',
-    'torist': 'toristinkirir4xj.onion',
-    'scihub': 'scihub22266oqcxt.onion',
+    'txtorcon.pet.onion': 'timaq4ygg2iegci7.onion',
+    'duckduckgo.pet.onion': '3g2upl4pq6kufc4m.onion',
+    'torist.pet.onion': 'toristinkirir4xj.onion',
+    'scihub.pet.onion': 'scihub22266oqcxt.onion',
 }
 
 

--- a/poc.py
+++ b/poc.py
@@ -96,13 +96,7 @@ class _TorNameServiceProtocol(ProcessProtocol, object):
 def spawn_name_service(reactor, name):
     proto = _TorNameServiceProtocol()
     try:
-        args = None
-        for service in _service_to_command:
-            if name.endswith("." + service):
-                args = _service_to_command[service]
-                break
-        if args is None:
-            raise KeyError()
+        args = _service_to_command[name]
     except KeyError:
         raise Exception(
             "No such service '{}'".format(name)
@@ -130,10 +124,18 @@ class _Attacher(object):
 
     @defer.inlineCallbacks
     def maybe_launch_service(self, name):
-        srv = self._services.get(name, None)
+        suffix = None
+        srv = None
+
+        for candidate_suffix in _service_to_command:
+            if name.endswith("." + candidate_suffix):
+                suffix = candidate_suffix
+                srv = self._services.get(suffix, None)
+                break
+
         if srv is None:
-            srv = yield spawn_name_service(self._reactor, name)
-            self._services[name] = srv
+            srv = yield spawn_name_service(self._reactor, suffix)
+            self._services[suffix] = srv
         defer.returnValue(srv)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
As discussed on #tor-dev IRC, this PR removes the restrictions that required the input and output TLD to be `.onion`.