### PR TITLE
Close the stream if a NameLookupError occurs

### DIFF
--- a/poc.py
+++ b/poc.py
@@ -148,6 +148,7 @@ class _Attacher(object):
         except NameLookupError as e:
             print("lookup failed: {}".format(e))
             remap = None
+            stream.close()
 
         if remap is not None and remap != stream.target_host:
             cmd = 'REDIRECTSTREAM {} {}'.format(stream.id, remap)


### PR DESCRIPTION
Without this, Tor Browser will keep waiting for the connection and eventually time out.  This commit makes Tor Browser immediately display an error instead.